### PR TITLE
Adding support for base url for llm calls and renamed openai key to be more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@
 
 .cursor
 .vscode
+.idea
 .claude
 *.txt

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Edit your `claude_mcp_settings.json` file:
       "command": "npx",
       "args": ["@hpbyte/h-codex-mcp"],
       "env": {
-        "OPENAI_API_KEY": "your_openai_api_key_here",
+        "LLM_API_KEY": "your_llm_api_key_here", 
+        "LLM_BASE_URL": "your_llm_base_url_here (default is openai baseurl: https://api.openai.com/v1)",
         "DB_CONNECTION_STRING": "postgresql://postgres:password@localhost:5432/h-codex"
       }
     }
@@ -91,8 +92,9 @@ Edit your `claude_mcp_settings.json` file:
 ## 🔧 Configuration Options
 
 | Environment Variable   | Description                      | Default                                                 |
-| ---------------------- | -------------------------------- | ------------------------------------------------------- |
-| `OPENAI_API_KEY`       | OpenAI API key for embeddings    | Required                                                |
+|------------------------|----------------------------------| ------------------------------------------------------- |
+| `LLM_API_KEY`          | LLM API key for embeddings       | Required                                                |
+| `LLM_BASE_URL`         | LLM Base url key for embeddings  | `https://api.openai.com/v1`                                                |
 | `EMBEDDING_MODEL`      | OpenAI model for embeddings      | `text-embedding-3-small`                                |
 | `CHUNK_SIZE`           | Maximum chunk size in characters | `1000`                                                  |
 | `SEARCH_RESULTS_LIMIT` | Max search results returned      | `10`                                                    |

--- a/packages/core/.env.example
+++ b/packages/core/.env.example
@@ -1,4 +1,5 @@
-OPENAI_API_KEY=your_openai_api_key_here
+LLM_API_KEY=your_llm_api_key_here
+LLM_BASE_URL=your_llm_base_url_here (default is openai baseurl: https://api.openai.com/v1)
 
 # db
 DB_CONNECTION_STRING=postgresql://postgres:password@localhost:5432/h-codex

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,7 +22,8 @@ pnpm add @hpbyte/h-codex-core
 Create a `.env` file with:
 
 ```
-OPENAI_API_KEY=your_openai_api_key_here
+LLM_API_KEY=your_llm_api_key_here
+LLM_BASE_URL=your_llm_base_url_here (default is openai baseurl: https://api.openai.com/v1)
 EMBEDDING_MODEL=text-embedding-3-small
 DB_CONNECTION_STRING=postgresql://postgres:password@localhost:5432/h-codex
 ```

--- a/packages/core/src/config/embedding.ts
+++ b/packages/core/src/config/embedding.ts
@@ -2,6 +2,7 @@ import { getEnvVar, getEnvNumber } from '../utils'
 
 interface EmbeddingsConfig {
   apiKey: string
+  baseURL: string
   model: string
   chunkSize: number
   searchResultsLimit: number
@@ -9,7 +10,8 @@ interface EmbeddingsConfig {
 }
 
 export const embeddingsConfig: EmbeddingsConfig = {
-  apiKey: getEnvVar('OPENAI_API_KEY'),
+  apiKey: getEnvVar('LLM_API_KEY'),
+  baseURL: getEnvVar('LLM_BASE_URL', 'https://api.openai.com/v1'),
   model: getEnvVar('EMBEDDING_MODEL', 'text-embedding-3-small'),
   chunkSize: getEnvNumber('CHUNK_SIZE', 1000),
   searchResultsLimit: getEnvNumber('SEARCH_RESULTS_LIMIT', 10),

--- a/packages/core/src/ingestion/embedder/index.ts
+++ b/packages/core/src/ingestion/embedder/index.ts
@@ -9,6 +9,7 @@ export class Embedder {
   constructor() {
     this.openai = new OpenAI({
       apiKey: embeddingsConfig.apiKey,
+      baseURL: embeddingsConfig.baseURL,
     })
   }
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -23,7 +23,8 @@ h-codex MCP server can be integrated with various AI assistants that support the
       "command": "npx",
       "args": ["@hpbyte/h-codex-mcp"],
       "env": {
-        "OPENAI_API_KEY": "your_openai_api_key_here",
+        "LLM_API_KEY": "your_llm_api_key_here",
+        "LLM_BASE_URL": "your_llm_base_url_here (default is openai baseurl: https://api.openai.com/v1)",
         "DB_CONNECTION_STRING": "postgresql://postgres:password@localhost:5432/h-codex"
       }
     }
@@ -40,7 +41,8 @@ h-codex MCP server can be integrated with various AI assistants that support the
    - **Command**: `npx`
    - **Arguments**: `["@hpbyte/h-codex-mcp"]`
    - **Environment Variables**:
-     _ `OPENAI_API_KEY`: `your-openai-api-key`
+     _ `LLM_API_KEY`: `your-llm-api-key`
+     _ `LLM_BASE_URL`: `your_llm_base_url_here (default is openai baseurl: https://api.openai.com/v1)`
      _ And any additional database configuration variables
 
 ### Other MCP Clients


### PR DESCRIPTION
1. Added support for customizable LLM API baseURL
2. Renamed environment variable from `OPENAI_API_KEY` to `LLM_API_KEY` to generalize usage.
3. Added `LLM_BASE_URL` environment variable to allow using different LLM providers beyond OpenAI.
4. Updated config and usage to support new config.

